### PR TITLE
Updating #add_associated_link to pass along the :name option along to the new associated form

### DIFF
--- a/lib/attribute_fu/associated_form_helper.rb
+++ b/lib/attribute_fu/associated_form_helper.rb
@@ -89,7 +89,7 @@ module AttributeFu
       
       @template.link_to_function(name, opts) do |page|
         page << "if (typeof #{variable} == 'undefined') #{variable} = 0;"
-        page << "new Insertion.Bottom(#{container}, new Template("+form_builder.render_associated_form(object, :fields_for => { :javascript => true }, :partial => partial).to_json+").evaluate({'number': --#{variable}}).gsub(/__number_/, #{variable}))"
+        page << "new Insertion.Bottom(#{container}, new Template("+form_builder.render_associated_form(object, :fields_for => { :javascript => true }, :partial => partial, :name => associated_name).to_json+").evaluate({'number': --#{variable}}).gsub(/__number_/, #{variable}))"
       end
     end
     


### PR DESCRIPTION
I know this is an outdated plugin, but we're still using it in some Rails 2.2.x apps. I noticed that the #add_associated_link method accepts a :name option, but it doesn't affect the rendered associated form fields, so if you have an association that specifies a :class_name you would get an error about "unknown attribute: [class_name]_attributes" . This patch just makes sure the name attribute gets passed along.
